### PR TITLE
feat: add under construction pages and shared layout

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -1,0 +1,89 @@
+:root{
+  --bg1:#0f0c29;
+  --bg2:#302b63;
+  --bg3:#24243e;
+  --bg4:#1a1a2e;
+  --neon-red:#ff005c;
+  --neon-purple:#7a00ff;
+  --link:#16d9ff;
+  --text-light:#ffffff;
+  --tile-radius:24px;
+}
+*{margin:0;padding:0;box-sizing:border-box;}
+html,body{
+  height:100%;
+  width:100%;
+  font-family:"Poppins",sans-serif;
+  color:var(--text-light);
+  background:#000;
+  scroll-behavior:smooth;
+}
+body{
+  background:linear-gradient(-45deg,var(--bg1),var(--bg2),var(--bg3),var(--bg4));
+  background-size:400% 400%;
+  animation:gradientShift 20s ease infinite;
+  display:flex;
+  flex-direction:column;
+}
+@keyframes gradientShift{0%{background-position:0% 50%;}50%{background-position:100% 50%;}100%{background-position:0% 50%;}}
+@media (prefers-reduced-motion:reduce){
+  body{animation:none;}
+  .tile{transition:none;}
+  .tile:hover,.tile:focus-visible{transform:none;}
+}
+.btn:focus-visible{outline:3px solid rgba(255,255,255,.7);outline-offset:2px;}
+header{
+  padding:1rem 1.5rem;
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  font-size:1.1rem;
+  font-weight:600;
+  letter-spacing:.5px;
+  text-shadow:0 0 8px rgba(0,255,255,.5),0 0 12px rgba(122,0,255,.5);
+  border-bottom:2px solid rgba(255,255,255,.08);
+  backdrop-filter:blur(6px);
+  background-color:rgba(0,0,0,.35);
+  position:sticky;
+  top:0;
+  z-index:10;
+}
+.branding{display:flex;align-items:center;gap:.5rem;color:#fff;text-decoration:none;}
+.branding img{height:40px;width:40px;}
+nav a{
+  color:var(--link);
+  text-decoration:none;
+  margin-left:1rem;
+  font-size:.95rem;
+  transition:color .15s;
+  padding:.25rem .4rem;
+  border-radius:.4rem;
+}
+nav a:hover{color:#fff;}
+nav a.active,nav a[aria-current="page"]{color:#fff;background:rgba(22,217,255,.12);}
+main{flex:1 1 auto;display:flex;flex-direction:column;align-items:center;text-align:center;}
+footer{text-align:center;font-size:.75rem;padding:1rem;color:rgba(255,255,255,.6);}
+.container{width:100%;max-width:900px;margin:0 auto;padding:2rem 1rem;}
+.btn{display:inline-block;padding:0.75rem 1.5rem;font-weight:600;border-radius:8px;text-decoration:none;}
+.btn-primary{background:#5865f2;color:#fff;box-shadow:0 0 10px rgba(88,101,242,.6);transition:transform .2s;}
+.btn-primary:hover{transform:scale(1.05);}
+.btn-ghost{border:2px solid var(--link);color:var(--link);background:transparent;transition:background .2s,color .2s;}
+.btn-ghost:hover{background:var(--link);color:#000;}
+#cta{margin:3rem auto 2rem;}
+#grid{width:100%;max-width:900px;display:grid;gap:20px;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));padding:0 1rem 3rem;}
+.tile{position:relative;border-radius:var(--tile-radius);overflow:hidden;aspect-ratio:1/1;display:block;cursor:pointer;border:2px solid var(--neon-purple);box-shadow:0 0 12px rgba(122,0,255,.5),0 0 28px rgba(122,0,255,.25);transition:transform .3s ease,box-shadow .3s ease;}
+.tile:hover,.tile:focus-visible{transform:scale(1.03);box-shadow:0 0 18px rgba(122,0,255,.8),0 0 40px rgba(122,0,255,.4);}
+.tile:focus-visible{outline:3px solid rgba(255,255,255,.7);outline-offset:2px;}
+.rs3{background:url('/images/RS3-button.png') center/contain no-repeat;}
+.mc{background:url('/images/MC-button.png') center/contain no-repeat;}
+.fps{background:url('/images/FPS-button.png') center/contain no-repeat;}
+.disc{background:url('/images/DISCORD-button.png') center/contain no-repeat;}
+.calendar-wrapper{width:100%;max-width:900px;aspect-ratio:16/9;box-shadow:0 0 20px rgba(0,200,255,.3);}
+iframe{width:100%;height:100%;border:none;}
+@media(max-width:600px){
+  main{padding:1rem;}
+  .calendar-wrapper{aspect-ratio:auto;height:100%;}
+}
+.uc-card{background:rgba(0,0,0,.35);padding:3rem 2rem;border-radius:var(--tile-radius);box-shadow:0 0 20px rgba(122,0,255,.4);max-width:500px;margin:auto;}
+.uc-card .actions{margin-top:1.5rem;display:flex;gap:1rem;justify-content:center;flex-wrap:wrap;}
+.discord-widget{width:100%;max-width:500px;height:500px;}

--- a/assets/site.js
+++ b/assets/site.js
@@ -1,0 +1,24 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const includeEls = document.querySelectorAll('[data-include]');
+  const loads = [];
+  includeEls.forEach(el => {
+    const url = el.getAttribute('data-include');
+    if (url) {
+      loads.push(
+        fetch(url).then(r => r.text()).then(html => {
+          el.outerHTML = html;
+        })
+      );
+    }
+  });
+  Promise.all(loads).then(() => {
+    const current = window.location.pathname.replace(/\/$/, '') || '/';
+    document.querySelectorAll('nav a').forEach(a => {
+      const href = a.getAttribute('href').replace(/\/$/, '') || '/';
+      if (href === current) {
+        a.classList.add('active');
+        a.setAttribute('aria-current', 'page');
+      }
+    });
+  });
+});

--- a/cal/index.html
+++ b/cal/index.html
@@ -7,154 +7,28 @@
   <meta name="description" content="Stay up to date with upcoming Myriad events on the community calendar." />
   <meta property="og:title" content="Myriad Event Calendar" />
   <meta property="og:description" content="Community events and activities at a glance." />
-  <meta property="og:type" content="website" />
   <meta property="og:url" content="https://myri.gg/cal/" />
+  <meta property="og:type" content="website" />
   <meta property="og:image" content="https://myri.gg/myri_logo.png" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Myriad Event Calendar" />
   <meta name="twitter:description" content="Community events and activities at a glance." />
   <meta name="twitter:image" content="https://myri.gg/myri_logo.png" />
-  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <link rel="icon" type="image/png" href="/myri_logo.png" />
-  <style>
-    :root {
-      --bg1: #0f0c29;
-      --bg2: #302b63;
-      --bg3: #24243e;
-      --bg4: #1a1a2e;
-      --neon-red: #ff005c;
-      --neon-purple: #7a00ff;
-      --text-light: #ffffff;
-      --link: #16d9ff;
-    }
-
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-
-    html, body {
-      height: 100%;
-      width: 100%;
-      font-family: "Poppins", sans-serif;
-      background: #000;
-      color: var(--text-light);
-      scroll-behavior: smooth;
-    }
-
-    body {
-      background: linear-gradient(-45deg, var(--bg1), var(--bg2), var(--bg3), var(--bg4));
-      background-size: 400% 400%;
-      animation: gradientShift 20s ease infinite;
-      display: flex;
-      flex-direction: column;
-    }
-
-    @keyframes gradientShift {
-      0% { background-position: 0% 50%; }
-      50% { background-position: 100% 50%; }
-      100% { background-position: 0% 50%; }
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-      body { animation: none; }
-    }
-
-    header {
-      padding: 1rem 1.5rem;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      font-size: 1.1rem;
-      font-weight: 600;
-      letter-spacing: .5px;
-      text-shadow: 0 0 8px rgba(0,255,255,0.5), 0 0 12px rgba(122,0,255,0.5);
-      border-bottom: 2px solid rgba(255,255,255,0.08);
-      backdrop-filter: blur(6px);
-      background-color: rgba(0,0,0,0.35);
-      position: sticky;
-      top: 0;
-      z-index: 10;
-    }
-
-    .branding {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      color: #fff;
-      text-decoration: none;
-    }
-
-    .logo { height: 40px; width: 40px; }
-
-    nav a {
-      color: var(--link);
-      text-decoration: none;
-      margin-left: 1rem;
-      font-size: 0.95rem;
-      transition: color 0.15s;
-      padding: .25rem .4rem;
-      border-radius: .4rem;
-    }
-    nav a:hover { color: #fff; }
-    nav a.active { color: #fff; background: rgba(22,217,255,.12); }
-
-    main {
-      flex: 1 1 auto;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      padding: 2rem 1rem;
-    }
-
-    .calendar-wrapper {
-      width: 100%;
-      max-width: 900px;
-      aspect-ratio: 16 / 9;
-      box-shadow: 0 0 20px rgba(0,200,255,0.3);
-    }
-
-    iframe {
-      width: 100%;
-      height: 100%;
-      border: none;
-    }
-
-    @media (max-width: 600px) {
-      main { padding: 1rem; }
-      .calendar-wrapper {
-        aspect-ratio: auto;
-        height: 100%;
-      }
-    }
-
-    footer {
-      text-align: center;
-      padding: 1rem 0;
-      font-size: 0.85rem;
-      border-top: 2px solid rgba(255,255,255,0.08);
-      backdrop-filter: blur(6px);
-      background-color: rgba(0,0,0,0.35);
-    }
-  </style>
+  <link rel="stylesheet" href="/assets/site.css" />
+  <script src="/assets/site.js" defer></script>
 </head>
 <body>
-  <header>
-    <a href="/" class="branding"><img src="/myri_logo.png" alt="Myri.gg logo" class="logo" />Myri.gg</a>
-    <nav>
-      <a href="/discord/">Discord</a>
-      <a href="/cal/" class="active">Calendar</a>
-      <a href="/minecraft/">Minecraft</a>
-    </nav>
-  </header>
-
-  <main>
+  <div data-include="/partials/header.html"></div>
+  <main class="container">
     <div class="calendar-wrapper">
       <iframe src="https://calendar.google.com/calendar/embed?src=myriads2x%40gmail.com&ctz=UTC&mode=AGENDA" title="Myriad event calendar"></iframe>
     </div>
   </main>
-
-  <footer>&copy; 2024 Myri.gg</footer>
-
+  <div data-include="/partials/footer.html"></div>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -167,4 +41,3 @@
   </script>
 </body>
 </html>
-

--- a/discord/index.html
+++ b/discord/index.html
@@ -3,69 +3,29 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Myriad Discord</title>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
+  <title>Myriad Discord | Myri.gg</title>
+  <meta name="description" content="Connect with the Myri community on Discord." />
+  <meta property="og:title" content="Myriad Discord" />
+  <meta property="og:description" content="Connect with the Myri community on Discord." />
+  <meta property="og:url" content="https://myri.gg/discord/" />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="https://myri.gg/myri_logo.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Myriad Discord" />
+  <meta name="twitter:description" content="Connect with the Myri community on Discord." />
+  <meta name="twitter:image" content="https://myri.gg/myri_logo.png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <link rel="icon" type="image/png" href="/myri_logo.png" />
-  <style>
-    * {
-      margin: 0;
-      padding: 0;
-      box-sizing: border-box;
-    }
-    html, body {
-      height: 100%;
-      width: 100%;
-      font-family: "Poppins", sans-serif;
-      background: #000;
-      overflow: hidden;
-    }
-    body {
-      background: linear-gradient(-45deg, #0f0c29, #302b63, #24243e, #1a1a2e);
-      background-size: 400% 400%;
-      animation: gradientShift 20s ease infinite;
-      display: flex;
-      flex-direction: column;
-    }
-    @keyframes gradientShift {
-      0% { background-position: 0% 50%; }
-      50% { background-position: 100% 50%; }
-      100% { background-position: 0% 50%; }
-    }
-    header {
-      padding: 1rem 1.5rem;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      color: #fff;
-      font-size: 2rem;
-      font-weight: 600;
-      letter-spacing: 2px;
-      text-shadow: 0 0 8px rgba(0,255,255,0.8), 0 0 16px rgba(138,43,226,0.8);
-      border-bottom: 2px solid rgba(255,255,255,0.1);
-      backdrop-filter: blur(6px);
-    }
-    .logo {
-      height: 40px;
-      margin-right: 10px;
-    }
-    main {
-      flex-grow: 1;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      padding: 1rem;
-    }
-    iframe {
-      width: 100%;
-      height: 100%;
-      border: none;
-    }
-  </style>
+  <link rel="stylesheet" href="/assets/site.css" />
+  <script src="/assets/site.js" defer></script>
 </head>
 <body>
-  <header><img src="/favicon.ico" alt="Myri.gg Logo" class="logo" /><span>Myriad Discord</span></header>
-  <main>
-    <iframe src="https://discord.com/widget?id=1063782757450391644&theme=dark" width="350" height="500" allowtransparency="true" frameborder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"></iframe>
+  <div data-include="/partials/header.html"></div>
+  <main class="container">
+    <iframe class="discord-widget" src="https://discord.com/widget?id=1063782757450391644&theme=dark" allowtransparency="true" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts" title="Myriad Discord"></iframe>
   </main>
+  <div data-include="/partials/footer.html"></div>
 </body>
 </html>

--- a/fps/index.html
+++ b/fps/index.html
@@ -1,1 +1,39 @@
-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>FPS — Myri.gg</title>
+  <meta name="description" content="FPS section is coming soon." />
+  <meta name="robots" content="noindex" />
+  <meta property="og:title" content="FPS — Under Construction" />
+  <meta property="og:description" content="This section is being built. Check back soon!" />
+  <meta property="og:url" content="https://myri.gg/fps/" />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="https://myri.gg/myri_logo.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="FPS — Under Construction" />
+  <meta name="twitter:description" content="This section is being built. Check back soon!" />
+  <meta name="twitter:image" content="https://myri.gg/myri_logo.png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="icon" type="image/png" href="/myri_logo.png" />
+  <link rel="stylesheet" href="/assets/site.css" />
+  <script src="/assets/site.js" defer></script>
+</head>
+<body>
+  <div data-include="/partials/header.html"></div>
+  <main class="container">
+    <section class="uc-card">
+      <h1>Under Construction</h1>
+      <p>This section is being built. Check back soon!</p>
+      <div class="actions">
+        <a class="btn btn-primary" href="/">Back to Home</a>
+        <a class="btn btn-ghost" href="/discord/">Join our Discord</a>
+      </div>
+    </section>
+  </main>
+  <div data-include="/partials/footer.html"></div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -5,107 +5,27 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Myri.gg — Play What You Love</title>
   <meta name="description" content="Jump into Myri: RuneScape 3, Minecraft, FPS and our Discord community." />
+  <meta property="og:title" content="Myri.gg — Play What You Love" />
+  <meta property="og:description" content="Jump into Myri: RuneScape 3, Minecraft, FPS and our Discord community." />
+  <meta property="og:url" content="https://myri.gg/" />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="https://myri.gg/myri_logo.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Myri.gg — Play What You Love" />
+  <meta name="twitter:description" content="Jump into Myri: RuneScape 3, Minecraft, FPS and our Discord community." />
+  <meta name="twitter:image" content="https://myri.gg/myri_logo.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <link rel="icon" type="image/png" href="/myri_logo.png" />
-  <style>
-    :root{
-      --bg1:#0f0c29;
-      --bg2:#302b63;
-      --bg3:#24243e;
-      --bg4:#1a1a2e;
-      --neon-red:#ff005c;
-      --neon-purple:#7a00ff;
-      --link:#16d9ff;
-      --text-light:#ffffff;
-      --tile-radius:24px;
-    }
-    *{margin:0;padding:0;box-sizing:border-box;}
-    html,body{
-      height:100%;width:100%;
-      font-family:"Poppins",sans-serif;
-      color:var(--text-light);
-      background:#000;
-      scroll-behavior:smooth;
-    }
-    body{
-      background:linear-gradient(-45deg,var(--bg1),var(--bg2),var(--bg3),var(--bg4));
-      background-size:400% 400%;
-      animation:gradientShift 20s ease infinite;
-      display:flex;flex-direction:column;
-    }
-    @keyframes gradientShift{
-      0%{background-position:0% 50%;}
-      50%{background-position:100% 50%;}
-      100%{background-position:0% 50%;}
-    }
-    @media (prefers-reduced-motion:reduce){
-      body{animation:none;}
-      .tile{transition:none;}
-      .tile:hover,.tile:focus-visible{transform:none;}
-    }
-    .btn:focus-visible{outline:3px solid rgba(255,255,255,.7);outline-offset:2px;}
-    header{
-      padding:1rem 1.5rem;display:flex;justify-content:space-between;align-items:center;
-      font-size:1.1rem;font-weight:600;letter-spacing:.5px;
-      text-shadow:0 0 8px rgba(0,255,255,.5),0 0 12px rgba(122,0,255,.5);
-      border-bottom:2px solid rgba(255,255,255,.08);
-      backdrop-filter:blur(6px);
-      background-color:rgba(0,0,0,.35);
-      position:sticky;top:0;z-index:10;
-    }
-    .branding{display:flex;align-items:center;gap:.5rem;color:#fff;text-decoration:none;}
-    .branding img{height:40px;width:40px;}
-    nav a{
-      color:var(--link);text-decoration:none;margin-left:1rem;font-size:.95rem;
-      transition:color .15s;padding:.25rem .4rem;border-radius:.4rem;
-    }
-    nav a:hover{color:#fff;}
-    main{flex:1 1 auto;display:flex;flex-direction:column;align-items:center;text-align:center;}
-    #cta{margin:3rem auto 2rem;}
-    #cta .btn{
-      display:inline-block;padding:1rem 2rem;font-size:1.3rem;font-weight:600;
-      color:#fff;background:#5865f2;text-decoration:none;border-radius:8px;
-      box-shadow:0 0 10px rgba(88,101,242,.6);transition:transform .2s;
-    }
-    #cta .btn:hover{transform:scale(1.05);}
-    #grid{
-      width:100%;max-width:900px;display:grid;gap:20px;
-      grid-template-columns:repeat(auto-fit,minmax(250px,1fr));
-      padding:0 1rem 3rem;
-    }
-    .tile{
-      position:relative;border-radius:var(--tile-radius);overflow:hidden;
-      aspect-ratio:1/1;display:block;cursor:pointer;
-      border:2px solid var(--neon-purple);
-      box-shadow:0 0 12px rgba(122,0,255,.5),0 0 28px rgba(122,0,255,.25);
-      transition:transform .3s ease,box-shadow .3s ease;
-    }
-    .tile:hover,.tile:focus-visible{
-      transform:scale(1.03);
-      box-shadow:0 0 18px rgba(122,0,255,.8),0 0 40px rgba(122,0,255,.4);
-    }
-    .tile:focus-visible{outline:3px solid rgba(255,255,255,.7);outline-offset:2px;}
-    .rs3{background:url('/images/RS3-button.png') center/contain no-repeat;}
-    .mc{background:url('/images/MC-button.png') center/contain no-repeat;}
-    .fps{background:url('/images/FPS-button.png') center/contain no-repeat;}
-    .disc{background:url('/images/DISCORD-button.png') center/contain no-repeat;}
-    footer{text-align:center;font-size:.75rem;padding:1rem;color:rgba(255,255,255,.6);}
-  </style>
+  <link rel="stylesheet" href="/assets/site.css" />
+  <script src="/assets/site.js" defer></script>
 </head>
 <body>
-  <header>
-    <a href="/" class="branding"><img src="/myri_logo.png" alt="Myri.gg logo"><span>Myri.gg</span></a>
-    <nav>
-      <a href="/minecraft/">Minecraft</a>
-      <a href="/cal/">Calendar</a>
-      <a href="/discord/">Discord</a>
-    </nav>
-  </header>
+  <div data-include="/partials/header.html"></div>
   <main>
     <section id="cta">
-      <a href="https://discord.gg/JoinMyriad" class="btn">Join Discord</a>
+      <a href="https://discord.gg/JoinMyriad" class="btn btn-primary">Join Discord</a>
     </section>
     <section id="grid">
       <a class="tile rs3" href="/runescape/" aria-label="RuneScape 3" role="button"></a>
@@ -114,6 +34,6 @@
       <a class="tile disc" href="/discord/" aria-label="Discord" role="button"></a>
     </section>
   </main>
-  <footer>© 2025 Myri.gg</footer>
+  <div data-include="/partials/footer.html"></div>
 </body>
 </html>

--- a/minecraft/index.html
+++ b/minecraft/index.html
@@ -18,6 +18,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
   <link rel="icon" type="image/png" href="/myri_logo.png" />
+  <link rel="stylesheet" href="/assets/site.css" />
+  <script src="/assets/site.js" defer></script>
   <style>
     :root {
       --bg1: #0f0c29;
@@ -402,17 +404,7 @@
   </style>
 </head>
 <body>
-  <header>
-    <a href="/" class="branding">
-      <img src="/favicon.ico" alt="Myri.gg Logo" class="logo" />
-      <span>Myri.gg</span>
-    </a>
-    <nav aria-label="Main Navigation">
-      <a href="/discord/">Discord</a>
-      <a href="/cal/">Calendar</a>
-      <a href="/minecraft/" class="active" aria-current="page">Minecraft</a>
-    </nav>
-  </header>
+  <div data-include="/partials/header.html"></div>
 
   <main>
     <section id="hero" aria-label="Myri Minecraft Hero">
@@ -676,7 +668,7 @@
     </section>
   </main>
 
-  <footer>&copy; 2024 Myri.gg</footer>
+  <div data-include="/partials/footer.html"></div>
 
   <div id="copy-feedback" class="sr-only" role="status" aria-live="polite" aria-atomic="true"></div>
 

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,0 +1,1 @@
+<footer>© 2025 Myri.gg</footer>

--- a/partials/head.html
+++ b/partials/head.html
@@ -1,0 +1,12 @@
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+<link rel="icon" type="image/png" href="/myri_logo.png" />
+<link rel="stylesheet" href="/assets/site.css" />
+<script src="/assets/site.js" defer></script>
+<meta property="og:type" content="website" />
+<meta property="og:image" content="https://myri.gg/myri_logo.png" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:image" content="https://myri.gg/myri_logo.png" />

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,0 +1,8 @@
+<header>
+  <a href="/" class="branding"><img src="/myri_logo.png" alt="Myri.gg logo"><span>Myri.gg</span></a>
+  <nav>
+    <a href="/minecraft/">Minecraft</a>
+    <a href="/cal/">Calendar</a>
+    <a href="/discord/">Discord</a>
+  </nav>
+</header>

--- a/runescape/index.html
+++ b/runescape/index.html
@@ -1,1 +1,39 @@
-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>RuneScape — Myri.gg</title>
+  <meta name="description" content="RuneScape section is coming soon." />
+  <meta name="robots" content="noindex" />
+  <meta property="og:title" content="RuneScape — Under Construction" />
+  <meta property="og:description" content="RuneScape section is being built. Check back soon!" />
+  <meta property="og:url" content="https://myri.gg/runescape/" />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="https://myri.gg/myri_logo.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="RuneScape — Under Construction" />
+  <meta name="twitter:description" content="RuneScape section is being built. Check back soon!" />
+  <meta name="twitter:image" content="https://myri.gg/myri_logo.png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="icon" type="image/png" href="/myri_logo.png" />
+  <link rel="stylesheet" href="/assets/site.css" />
+  <script src="/assets/site.js" defer></script>
+</head>
+<body>
+  <div data-include="/partials/header.html"></div>
+  <main class="container">
+    <section class="uc-card">
+      <h1>Under Construction</h1>
+      <p>This section is being built. Check back soon!</p>
+      <div class="actions">
+        <a class="btn btn-primary" href="/">Back to Home</a>
+        <a class="btn btn-ghost" href="/discord/">Join our Discord</a>
+      </div>
+    </section>
+  </main>
+  <div data-include="/partials/footer.html"></div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- centralize styles/scripts into `assets/site.css` and `assets/site.js`
- inject shared header and footer on every page via partial includes
- add polished "Under Construction" pages for RuneScape and FPS with `noindex`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c58f7ba4108330abab3f5a60150a72