### PR TITLE
Fix Minecraft hero image overlap on mobile

### DIFF
--- a/minecraft/index.html
+++ b/minecraft/index.html
@@ -113,7 +113,7 @@
       min-height: 72vh;
       padding: 6rem 1rem 4rem;
       background-image: url("fantasy-mc-header.png");
-      background-size: contain;         /* show entire image without cropping */
+      background-size: cover;           /* fill width on larger screens */
       background-repeat: no-repeat;
       background-position: center;      /* keep image centered */
       background-attachment: scroll;    /* no parallax issues on mobile */
@@ -124,6 +124,39 @@
       justify-content: center;
       align-items: center;
       overflow: hidden;
+    }
+
+    /* hero image shown on small screens */
+    .hero-img {
+      display: none;
+    }
+
+    @media (max-width: 600px) {
+      #hero {
+        background-image: none;      /* use inline image instead */
+        padding-top: 1.5rem;
+      }
+
+      .hero-img {
+        display: block;
+        width: 100%;
+        height: auto;
+        border-radius: 0.75rem;
+        margin-bottom: 1.25rem;
+      }
+
+      /* ensure text appears above gradient overlay */
+      #hero h1,
+      #hero p.subtitle,
+      .hero-actions,
+      .hero-link {
+        position: relative;
+        z-index: 2;
+      }
+
+      #hero::after {
+        z-index: 1;
+      }
     }
 
     #hero::after {
@@ -408,6 +441,7 @@
 
   <main>
     <section id="hero" aria-label="Myri Minecraft Hero">
+      <img src="fantasy-mc-header.png" alt="A view of the Fantasy MC world" class="hero-img" />
       <h1>Myri Minecraft Server</h1>
       <p class="subtitle">Fantasy MC Fabric. Magic, mystery, and adventure.</p>
       <div class="hero-actions">


### PR DESCRIPTION
## Summary
- Show hero image as standalone image on small screens so it isn't hidden behind text
- Add responsive styles to hide background image and display mobile-friendly hero image
- Restore full-width hero background on larger screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5c56c33788330a7d18a5b887593e7