### PR TITLE
Add reusable hero template and apply to Minecraft page

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -88,3 +88,12 @@ iframe{width:100%;height:100%;border:none;}
 .uc-card{background:rgba(0,0,0,.35);padding:3rem 2rem;border-radius:var(--tile-radius);box-shadow:0 0 20px rgba(122,0,255,.4);max-width:500px;margin:auto;text-align:center;}
 .uc-card .actions{margin-top:1.5rem;display:flex;gap:1rem;justify-content:center;flex-wrap:wrap;}
 .discord-widget{width:100%;max-width:500px;height:500px;}
+
+/* Hero template */
+.hero{display:grid;grid-template-rows:auto auto;justify-items:center;text-align:center;padding:clamp(1rem,8vh,3rem) 1rem;gap:1rem;}
+.hero-image{width:100%;max-width:900px;height:min(40vh,400px);background-repeat:no-repeat;background-position:center;background-size:contain;}
+.hero h1{font-size:clamp(1.9rem,3.4vw,2.6rem);line-height:1.2;text-shadow:0 0 12px rgba(122,0,255,.75);padding:.25rem .6rem;border-radius:.6rem;}
+.hero .subtitle{margin-top:.5rem;font-size:clamp(1rem,2.2vw,1.15rem);opacity:.95;}
+.hero-actions{margin-top:1.25rem;display:flex;gap:1rem;flex-wrap:wrap;}
+.hero-link{margin-top:1rem;color:var(--link);text-decoration:underline;font-size:.95rem;}
+.hero-link:hover{color:#fff;}

--- a/minecraft/index.html
+++ b/minecraft/index.html
@@ -108,106 +108,8 @@
 
     main { flex: 1 1 auto; }
 
-    /* Hero */
-    #hero {
-      min-height: 72vh;
-      padding: 6rem 1rem 4rem;
-      background-image: url("fantasy-mc-header.png");
-      background-size: cover;           /* fill width on larger screens */
-      background-repeat: no-repeat;
-      background-position: center;      /* keep image centered */
-      background-attachment: scroll;    /* no parallax issues on mobile */
-      position: relative;
-      text-align: center;
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      overflow: hidden;
-    }
-
-    /* hero image shown on small screens */
-    .hero-img {
-      display: none;
-    }
-
-    @media (max-width: 600px) {
-      #hero {
-        background-image: none;      /* use inline image instead */
-        padding-top: 1.5rem;
-      }
-
-      .hero-img {
-        display: block;
-        width: 100%;
-        height: auto;
-        border-radius: 0.75rem;
-        margin-bottom: 1.25rem;
-      }
-
-      /* ensure text appears above gradient overlay */
-      #hero h1,
-      #hero p.subtitle,
-      .hero-actions,
-      .hero-link {
-        position: relative;
-        z-index: 2;
-      }
-
-      #hero::after {
-        z-index: 1;
-      }
-    }
-
-    #hero::after {
-      content: "";
-      position: absolute;
-      inset: 0;
-      /* safer readable overlay than blend modes */
-      background: linear-gradient(
-        to bottom,
-        rgba(10, 0, 25, .35) 0%,
-        rgba(10, 0, 25, .55) 70%,
-        rgba(10, 0, 25, .7) 100%
-      );
-      pointer-events: none;
-    }
-
-    #hero h1 {
-      font-size: clamp(1.9rem, 3.4vw, 2.6rem);
-      line-height: 1.2;
-      z-index: 1;
-      text-shadow: 0 0 12px rgba(122,0,255,.75);
-      padding: .25rem .6rem;
-      border-radius: .6rem;
-    }
-
-    #hero p.subtitle {
-      margin-top: 0.5rem;
-      font-size: clamp(1rem, 2.2vw, 1.15rem);
-      z-index: 1;
-      opacity: .95;
-    }
-
-    .hero-actions {
-      margin-top: 1.25rem;
-      display: flex;
-      gap: 1rem;
-      flex-wrap: wrap;
-      z-index: 1;
-    }
-
-    .hero-link {
-      margin-top: 1rem;
-      color: var(--link);
-      text-decoration: underline;
-      font-size: 0.95rem;
-      z-index: 1;
-    }
-    .hero-link:hover { color: #fff; }
-
-    /* Buttons */
-    .btn {
+      /* Buttons */
+      .btn {
       display: inline-flex;
       align-items: center;
       justify-content: center;
@@ -440,8 +342,8 @@
   <div data-include="/partials/header.html"></div>
 
   <main>
-    <section id="hero" aria-label="Myri Minecraft Hero">
-      <img src="fantasy-mc-header.png" alt="A view of the Fantasy MC world" class="hero-img" />
+    <section class="hero" aria-label="Myri Minecraft Hero">
+      <div class="hero-image" style="background-image:url('fantasy-mc-header.png');"></div>
       <h1>Myri Minecraft Server</h1>
       <p class="subtitle">Fantasy MC Fabric. Magic, mystery, and adventure.</p>
       <div class="hero-actions">

--- a/partials/hero.html
+++ b/partials/hero.html
@@ -1,0 +1,8 @@
+<section class="hero">
+  <div class="hero-image" style="background-image:url('/path/to/hero.png');"></div>
+  <h1>Hero Title</h1>
+  <p class="subtitle">Subtitle text goes here</p>
+  <div class="hero-actions">
+    <a href="#" class="btn">Action</a>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- add hero template partial with background-size contain and image above heading
- centralize hero styles with responsive padding
- use hero template on Minecraft page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5dc585374833092375f48327a6b66